### PR TITLE
Fix various bugs and allow api keyword

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
         "editor.formatOnSave": true
     },
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -13,7 +13,7 @@
         "clean": "shx rm -rf ./dist ./out",
         "test": "jest --forceExit",
         "test:coverage": "jest --forceExit --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura --coverageReporters=html --coverageReporters=json",
-        "test:cython": "cd src/tests-cython && jest --forceExit"
+        "test:cython": "cd src/tests-cython && jest"
     },
     "dependencies": {
         "@iarna/toml": "2.2.5",

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -1118,6 +1118,9 @@ function printTypeWithCythonDetails(type: Type, objName: string) {
         if (details.isPublic) {
             prefixes.push('public');
         }
+        if (details.isApi) {
+            prefixes.push('api');
+        }
         if (details.isConst) {
             prefixes.push('const');
         }

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -299,6 +299,7 @@ export namespace TypeBase {
             isConst: node ? CTypeNode.isConstant(node) : false,
             isVolatile: node ? CTypeNode.isVolatile(node) : false,
             isPublic: node ? CTypeNode.isPublic(node) : false,
+            isApi: node ? CTypeNode.isApi(node) : false,
             isReadOnly: node ? CTypeNode.isReadOnly(node) : false,
             numMods: node ? CTypeNode.numModifiers(node) : [],
             trailType: node ? CTypeNode.trailType(node) : CTrailType.None,
@@ -606,6 +607,7 @@ export interface CythonDetails {
     isVolatile?: boolean;
     isReadOnly?: boolean;
     isPublic?: boolean;
+    isApi?: boolean;
     numMods?: string[]; // Numeric modifiers
     trailType?: CTrailType;
 

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -500,6 +500,17 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
     return diagSettings;
 }
 
+/** Cython: minimal diagnostics — only syntax/parse errors. Suppresses import and undefined-variable noise for .pyx/.pxd. */
+export function getCythonDiagnosticRuleSet(): DiagnosticRuleSet {
+    const diagSettings: DiagnosticRuleSet = {
+        ...getOffDiagnosticRuleSet(),
+        reportMissingImports: 'none',
+        reportMissingModuleSource: 'none',
+        reportUndefinedVariable: 'none',
+    };
+    return diagSettings;
+}
+
 export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
     const diagSettings: DiagnosticRuleSet = {
         printUnknownAsAny: false,
@@ -816,6 +827,10 @@ export class ConfigOptions {
 
         if (typeCheckingMode === 'off') {
             return getOffDiagnosticRuleSet();
+        }
+
+        if (typeCheckingMode === 'cython') {
+            return getCythonDiagnosticRuleSet();
         }
 
         return getBasicDiagnosticRuleSet();

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -174,6 +174,7 @@ namespace Keywords {
         'const',
         'readonly',
         'public',
+        'api',
         'signed',
         'unsigned',
         'long',

--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -2572,6 +2572,10 @@ export namespace CTypeNode {
         return hasModifier(node, KeywordType.Public);
     }
 
+    export function isApi(node: CTypeNode) {
+        return hasModifier(node, KeywordType.Api);
+    }
+
     export function isReadOnly(node: CTypeNode) {
         return hasModifier(node, KeywordType.Readonly);
     }

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -102,6 +102,7 @@ const _keywords: Map<string, KeywordType> = new Map([
     ['const', KeywordType.Const],
     ['readonly', KeywordType.Readonly],
     ['public', KeywordType.Public],
+    ['api', KeywordType.Api],
     ['signed', KeywordType.Signed],
     ['unsigned', KeywordType.Unsigned],
     ['long', KeywordType.Long],

--- a/packages/pyright-internal/src/parser/tokenizerTypes.ts
+++ b/packages/pyright-internal/src/parser/tokenizerTypes.ts
@@ -167,6 +167,7 @@ export const enum KeywordType {
     Const,
     Readonly,
     Public,
+    Api,
     Signed,
     Unsigned,
     Long,
@@ -196,6 +197,7 @@ export const varModifiers = [
     KeywordType.Readonly,
     KeywordType.Inline,
     KeywordType.Public,
+    KeywordType.Api,
     KeywordType.Volatile,
 ];
 
@@ -218,6 +220,7 @@ export const softKeywords = [
     KeywordType.Const,
     KeywordType.Readonly,
     KeywordType.Public,
+    KeywordType.Api,
     KeywordType.Signed,
     KeywordType.Unsigned,
     KeywordType.Long,

--- a/packages/pyright-internal/src/server.ts
+++ b/packages/pyright-internal/src/server.ts
@@ -226,7 +226,14 @@ export class PyrightServer extends LanguageServerBase {
                     });
                     serverSettings.includePaths = cythonPaths;
                 }
+                if (cythonSection.typeCheckingMode !== undefined && isString(cythonSection.typeCheckingMode)) {
+                    serverSettings.typeCheckingMode = cythonSection.typeCheckingMode;
+                }
             }
+
+            // ! Cython: use minimal diagnostics for .pyx/.pxd to avoid false positives
+            // (missing imports, undefined vars from cimports/C types). Set cython.typeCheckingMode to override.
+            serverSettings.typeCheckingMode = serverSettings.typeCheckingMode ?? 'cython';
         } catch (error) {
             this.console.error(`Error reading settings: ${error}`);
         }

--- a/packages/pyright-internal/src/tests-cython/tests/cython.test.ts
+++ b/packages/pyright-internal/src/tests-cython/tests/cython.test.ts
@@ -96,6 +96,10 @@ test('new_keyword.pyx', () => {
     runDiagnosticTest('new_keyword.pyx');
 });
 
+test('api_keyword.pyx', () => {
+    runDiagnosticTest('api_keyword.pyx');
+});
+
 test('type_as_class.pyx', () => {
     runDiagnosticTest('type_as_class.pyx');
 });

--- a/packages/pyright-internal/src/tests-cython/tests/cythonTestUtils.ts
+++ b/packages/pyright-internal/src/tests-cython/tests/cythonTestUtils.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import * as path from 'path';
 
+import { ConfigOptions } from '../../common/configOptions';
 import { DiagnosticCategory } from '../../common/diagnostic';
 import * as TestUtils from '../../tests/testUtils';
 
@@ -187,6 +188,9 @@ export function sampleFile(filename: string) {
 export function runDiagnosticTest(fileName: string) {
     const content = TestUtils.readSampleFile(sampleFile(fileName));
     const expected = extractInlineExpectations(content);
-    const results = TestUtils.typeAnalyzeSampleFiles([sampleFile(fileName)])
+    const configOptions = new ConfigOptions('.');
+    // So `cimport` / `from … cimport` resolve `.pxd` next to samples (portable across machines).
+    configOptions.includePaths = [path.resolve(__dirname, 'samples')];
+    const results = TestUtils.typeAnalyzeSampleFiles([sampleFile(fileName)], configOptions);
     validateInlineResults(results, expected);
 }

--- a/packages/pyright-internal/src/tests-cython/tests/samples/api_keyword.pyx
+++ b/packages/pyright-internal/src/tests-cython/tests/samples/api_keyword.pyx
@@ -1,0 +1,2 @@
+cdef int api
+api = 1

--- a/packages/pyright-internal/src/tests-cython/tests/samples/import.pyx
+++ b/packages/pyright-internal/src/tests-cython/tests/samples/import.pyx
@@ -1,6 +1,6 @@
-cimport libc.math # expect-unused: "libc.math" is not accessed
-from libc.math cimport sinf
-from libc.math cimport cosf as func
+cimport import_stub # expect-unused: "import_stub" is not accessed
+from import_stub cimport sinf
+from import_stub cimport cosf as func
 
 a = sinf
 b = func

--- a/packages/pyright-internal/src/tests-cython/tests/samples/import_stub.pxd
+++ b/packages/pyright-internal/src/tests-cython/tests/samples/import_stub.pxd
@@ -1,0 +1,4 @@
+# Minimal stub for import.pyx tests (avoid libc.math — resolution varies by Python/Cython install).
+
+cdef float sinf(float x)
+cdef float cosf(float x)


### PR DESCRIPTION
## Cyright module — PR description

### Summary

Adds Cython `api` keyword support in the parser and type system, and wires the Cython extension settings (`cython.typeCheckingMode`, `cython.includePaths`) into the language server.

---

### Commit

- **`bccdab3cf`** — Fix various bugs and allow api keyword

---

### Changes

**1. Cython `api` keyword**

- **`tokenizerTypes.ts`** — New `KeywordType.Api`, added to `varModifiers` and `softKeywords` so `api` is accepted where `public` is (e.g. `cdef public api void foo()`).
- **`tokenizer.ts`** — Map `'api'` → `KeywordType.Api`.
- **`parseNodes.ts`** — Add `CTypeNode.isApi(node)` (same pattern as `isPublic`).
- **`types.ts`** — Add `isApi?: boolean` to `CythonDetails`; set it in `cloneForCType` from `CTypeNode.isApi(node)`.
- **`typePrinter.ts`** — When printing types, add `'api'` to the modifier list when `details.isApi`.
- **`completionProvider.ts`** — Add `'api'` to the Cython keyword list for completions.

**2. Cython configuration**

- **`configOptions.ts`** — Support `typeCheckingMode === 'cython'` and use a Cython-specific diagnostic rule set (e.g. `getCythonDiagnosticRuleSet()`).
- **`server.ts`** — Read `cython.typeCheckingMode` and `cython.includePaths` from the `cython` config section; default `typeCheckingMode` to `'cython'` when running as the Cython extension.

### References

- Cython C API declarations: https://cython.readthedocs.io/en/latest/src/userguide/external_C_code.html#c-api-declarations